### PR TITLE
Ajouter les photos des députés (list des deptes posant probleme)

### DIFF
--- a/app/depute/[slug]/layout.tsx
+++ b/app/depute/[slug]/layout.tsx
@@ -33,7 +33,11 @@ export default async function Page({
     <Box sx={{ maxWidth: "1024px", mx: "auto", my: 5 }}>
       <Stack direction="row" justifyContent="space-between">
         <Box sx={{ display: "flex", flexDirection: "row" }}>
-          <Avatar sx={{ bgcolor: "grey.200", width: 100, height: 100, mr: 1 }}>
+          <Avatar
+            sx={{ bgcolor: "grey.200", width: 100, height: 100, mr: 1 }}
+            alt={`${depute.prenom} ${depute.nom}`}
+            src={`https://www.nosdeputes.fr/depute/photo/${depute.slug}/${128}`}
+          >
             {depute.prenom[0]}
             {depute.nom[0]}
           </Avatar>

--- a/app/deputes/DeputesView.tsx
+++ b/app/deputes/DeputesView.tsx
@@ -108,6 +108,7 @@ function Deputes({
           return (
             <DeputeCard
               key={uid}
+              slug={slug}
               prenom={prenom}
               nom={nom}
               secondaryText={

--- a/components/folders/DeputeCard.tsx
+++ b/components/folders/DeputeCard.tsx
@@ -14,6 +14,7 @@ import Link from "next/link";
 type DeputeCardProps<RootComponent extends React.ElementType = "div"> = {
   prenom: string;
   nom: string;
+  slug: string;
   secondaryText?: string;
   group?: {
     color: string;
@@ -58,7 +59,11 @@ export default function DeputeCard<RootComponent extends React.ElementType>(
       {...other}
     >
       <Box sx={{ display: "flex", minWidth: 0 }}>
-        <Avatar sx={{ height: 40, width: 40 }}>
+        <Avatar
+          sx={{ height: 40, width: 40 }}
+          alt={`${prenom} ${nom}`}
+          src={`https://www.nosdeputes.fr/depute/photo/${slug}/${52}`}
+        >
           {prenom[0].toUpperCase()}
           {nom[0].toUpperCase()}
         </Avatar>

--- a/components/folders/VotesTab/VotesDeputes.tsx
+++ b/components/folders/VotesTab/VotesDeputes.tsx
@@ -79,6 +79,7 @@ export function VotesDeputes({ votes }: { votes: Vote[] }) {
                 {innerVotes.map(
                   ({
                     slug,
+                    depute_slug,
                     prenom,
                     nom,
                     group_libelle,
@@ -89,6 +90,7 @@ export function VotesDeputes({ votes }: { votes: Vote[] }) {
                   }) => (
                     <DeputeCard
                       key={slug}
+                      slug={depute_slug}
                       prenom={prenom}
                       nom={nom}
                       group={{

--- a/components/folders/VotesTab/VotesGroups.tsx
+++ b/components/folders/VotesTab/VotesGroups.tsx
@@ -114,9 +114,17 @@ export function VotesGroups({ votes }: { votes: Vote[] }) {
                   }}
                 >
                   {votes.map(
-                    ({ slug, prenom, nom, positionVote, group_position }) => (
+                    ({
+                      slug,
+                      depute_slug,
+                      prenom,
+                      nom,
+                      positionVote,
+                      group_position,
+                    }) => (
                       <DeputeCard
                         key={slug}
+                        slug={depute_slug}
                         prenom={prenom}
                         nom={nom}
                         vote={positionVote}

--- a/repository/database.ts
+++ b/repository/database.ts
@@ -350,7 +350,12 @@ export async function getDossierVotes(
       .rightJoin("Vote", "VoteActeLegislatif.voteRefUid", "Vote.scrutinRefUid")
       .leftJoin(
         function () {
-          this.select(["uid as acteur_uid", "prenom", "nom"])
+          this.select([
+            "uid as acteur_uid",
+            "prenom",
+            "nom",
+            "slug as depute_slug",
+          ])
             .from("Acteur")
             .as("acteur");
         },


### PR DESCRIPTION
Pour l'instant je me sert de l'API de nosDeputes.fr qui semble fonctionné comme suit:

https://www.nosdeputes.fr/depute/photo/[depute slug]/[height in px]

## Problemes detecté

Petit problem avec la deputes de outremeres [Emeline K/Bidi](https://www.nosdeputes.fr/emeline-k-bidi)

Son slug sur le site actuel est `emeline-k-bidi` mais dans note base de données c'est `emeline-kbidi`

Autres deputes sans photos (je les ai tous verifié, mais je n'ai pas cherché pourquoi la photo plantait)

Alexandra Martin (`alexandra-martin-alpes-maritimes` et `alexandra-martin-gironde`)
Claire Colomb-Pitollat (`claire-colomb-pitollat`)
Guillaume Gouffier Valente (`guillaume-gouffier-valente`)


## Screen shot

![image](https://github.com/louis-sanna-eki/nosdeputes-front/assets/45398769/2fc439d3-7502-428b-afd4-937b1a1667f5)
![image](https://github.com/louis-sanna-eki/nosdeputes-front/assets/45398769/73be1ca0-06f0-4a31-8b18-4be04be61046)
