### PR TITLE
Remove duplicated oganisation for depute

### DIFF
--- a/app/depute/[slug]/Mandats.tsx
+++ b/app/depute/[slug]/Mandats.tsx
@@ -21,14 +21,29 @@ export default function Mandats({ mandats }: { mandats: any[] }) {
   > = mandats
     .filter((m) => !ignoredTypeOrgane.includes(m.typeOrgane))
     .reduce((acc, mandat) => {
-      const { typeOrgane, libelle, libQualiteSex } = mandat;
+      const { typeOrgane, codeQualite, libelle, libQualiteSex, organeRefUid } =
+        mandat;
+
+      const existingMandat = acc[typeOrgane]?.find(
+        (m: any) => m.organeRefUid === organeRefUid
+      );
+
+      if (existingMandat && codeQualite === "Membre") {
+        // Le mandat exist deja inutile d'ajouter qu'il/elle est membre du groupe
+        return acc;
+      }
+
       return {
         ...acc,
         [typeOrgane]: [
-          ...(acc[typeOrgane] ?? []),
+          ...(acc[typeOrgane]?.filter(
+            (m: any) => m.organeRefUid !== organeRefUid
+          ) ?? []),
           {
             libelle,
             libQualiteSex,
+            codeQualite,
+            organeRefUid,
           },
         ],
       };


### PR DESCRIPTION
Quand un deputé à un role type secrétaire, president, ... d'un group, il en est aussi membre. Cette PR enlève l'affichage des membre si le/la deputé à d'autre responsabilité dans le group